### PR TITLE
Dynamically load google api dependencies on click

### DIFF
--- a/src/google-picker.js
+++ b/src/google-picker.js
@@ -61,7 +61,7 @@
         /**
          * Load required modules
          */
-        function instanciate () {
+        function instantiate () {
           gapi.load('auth', { 'callback': onApiAuthLoad });
           gapi.load('picker');
         }
@@ -139,11 +139,9 @@
           });
         }
 
-        gapi.load('auth');
-        gapi.load('picker');
-
         element.bind('click', function (e) {
-          instanciate();
+	  /* dynamically load dependencies only on click */
+          instantiate();
         });
       }
     }


### PR DESCRIPTION
My app functions offline, so I only load Drive on user request (click). But angular picker directive is part of my page so it loads before they can click the button. What I found in my console log was some crashing of picker because gapi is null if I'm offline.

I looked at the code and I only see one place where gapi is used at load time:

Around line 142:
gapi.load('auth');
gapi.load('picker');

These seem unnecessary to me since they are also loaded in the instantiate() function. Instantiate is bound to click. So those modules will load at the appropriate time.

Recommend that the two early calls be removed unless there's a good reason to keep them. I remove them and everything functions the same for me.

At the very least I recommend refactor by calling instantiate instead of doing the same thing in two places. Also in instantiate() check gapi before invoking load.
